### PR TITLE
Refactoring of `?SORT` and `?assertJson`

### DIFF
--- a/include/testing.hrl
+++ b/include/testing.hrl
@@ -20,7 +20,6 @@
 -define(MECK_AND_RESET(Module, Funs), ?MECK(Module, Funs), meck:reset(Module)).
 -define(UNMECK, test_utils:unmeck_modules()).
 -define(UNMECK(Module), test_utils:unmeck_module(Module)).
--define(SORT(List), lists:sort(List)).
 
 -define(assertContains(Element, List), begin ((
     fun(E, L) ->
@@ -63,19 +62,12 @@
 
 
 -define(SORT_PROPERTIES_IN_JSON(U), begin((
-    %For me is tricky - i leaved commented lines for better understanding and code review.
         fun
              SSort([FirstTuple | RestOfTuples]) when is_tuple(FirstTuple) ->
-                 %?debugFmt("3 List of many tuples: ~p", [[FirstTuple, RestOfTuples]]),
-                 R = ?SORT(lists:merge([SSort(FirstTuple)], SSort(RestOfTuples))),
-                 %?debugFmt("3 R: ~p", [R]),
-                 R;
+                 lists:sort(lists:merge([SSort(FirstTuple)], SSort(RestOfTuples)));
 
              SSort(ArrayOfElements) when is_list(ArrayOfElements) ->
-                 %?debugFmt("4 List of many elements: ~p", [ArrayOfElements]),
-                 R = [SSort(E) || E <- ArrayOfElements],
-                 %?debugFmt("4 R: ~p", [R]),
-                 R;
+                 [SSort(E) || E <- ArrayOfElements];
 
              SSort({AttrName, AttrValue}) when is_atom(AttrName) ->
                  SSort({atom_to_binary(AttrName, utf8), AttrValue});
@@ -84,18 +76,14 @@
                  SSort({integer_to_binary(AttrName), AttrValue});
 
              SSort({AttrName, AttrValue}) ->
-                 %?debugFmt("5 Tuple: ~p", [{AttrName, AttrValue}]),
-                 R = {AttrName, SSort(AttrValue)},
-                 %?debugFmt("5 R: ~p", [R]),
-                 R;
+                 {AttrName, SSort(AttrValue)};
 
              SSort(Primitive) ->
-                 %?debugFmt("Primitive: ~p", [Primitive]),
                  Primitive
          end
 ))(U)end).
 
--define(assertJson(Expected, Actual), begin ((
+-define(assertJsonEqual(Expected, Actual), begin ((
     fun(E, A) ->
         StripWhitespaces = fun
               (Binary) when is_binary(Binary) ->
@@ -111,8 +99,8 @@
     end
 )(Expected, Actual))end).
 
--define(assertEqualUnordered(Expected, Actual), ?assertEqual(?SORT(Expected), ?SORT(Actual))).
--define(assertNotEqualUnordered(Expected, Actual), ?assertNotEqual(?SORT(Expected), ?SORT(Actual))).
+-define(assertEqualUnordered(Expected, Actual), ?assertEqual(lists:sort(Expected), lists:sort(Actual))).
+-define(assertNotEqualUnordered(Expected, Actual), ?assertNotEqual(lists:sort(Expected), lists:sort(Actual))).
 
 -define(assertCalledOnce(Module, Function, Args), ?assertCalled(1, Module, Function, Args)).
 

--- a/test/test_utils_tests.erl
+++ b/test/test_utils_tests.erl
@@ -114,7 +114,7 @@ wait_for_process_stopped_test() ->
 positive_comparision_of_json_test() ->
     JsonA = <<"{\"list1\":[1,2,{\"a\":1},[{\"b\":3,\"c\":4}]],\"list2\":[10,20,{\"a\":10},[{\"b\":30,\"c\":40}]]}">>,
     JsonB = <<"{\"list2\":[10,20,{\"a\":10},[{\"b\":30,\"c\":40}]],\"list1\":[1,2,{\"a\":1},[{\"b\":3,\"c\":4}]]}">>,
-    ?assertJson(JsonA, JsonB).
+    ?assertJsonEqual(JsonA, JsonB).
 
 second_positive_comparision_of_json_test() ->
     JsonC = <<"{
@@ -146,16 +146,16 @@ second_positive_comparision_of_json_test() ->
         ]
     }">>,
     %% [{\"c\":40,\"b\":30}] -> [{\"b\":30,\"c\":40}] should make no difference
-    ?assertJson(JsonC, JsonD).
+    ?assertJsonEqual(JsonC, JsonD).
 
 other_json_sorting_cases_test() ->
     EmptyObjectJson = <<"{\"attributes\":{},\"aaa\":5}">>,
-    ?assertJson(EmptyObjectJson, EmptyObjectJson),
+    ?assertJsonEqual(EmptyObjectJson, EmptyObjectJson),
     EmptyArrayJson = <<"{\"attributes\":[],\"aaa\":5}">>,
-    ?assertJson(EmptyArrayJson, EmptyArrayJson),
+    ?assertJsonEqual(EmptyArrayJson, EmptyArrayJson),
     MixedKeyJsonTerm1 = [{bbb, <<"string">>}, {<<"aaa">>, 15}, {42, true}, {41, false}],
     MixedKeyJsonTerm2 = [{<<"bbb">>, <<"string">>}, {aaa, 15}, {42, true}, {<<"41">>, false}],
-    ?assertJson(MixedKeyJsonTerm1, MixedKeyJsonTerm2).
+    ?assertJsonEqual(MixedKeyJsonTerm1, MixedKeyJsonTerm2).
 
 negative_comparision_of_json_test() ->
     JsonC = <<"[


### PR DESCRIPTION
Use direct call to `lists:sort/1` instead of `?SORT` macro that could be used in some other project.
Rename `?assertJson` to `?assertJsonEqual`.